### PR TITLE
Convert undefined to '' inside path.extname()

### DIFF
--- a/lib/atom-react.coffee
+++ b/lib/atom-react.coffee
@@ -123,7 +123,7 @@ class AtomReact
     path = require 'path'
 
     # Check if file extension is .jsx or the file requires React
-    extName = path.extname(editor.getPath())
+    extName = path.extname(editor.getPath() or '')
     if extName is ".jsx" or ((extName is ".js" or extName is ".es6") and @isReact(editor.getText()))
       jsxGrammar = atom.grammars.grammarsByScopeName["source.js.jsx"]
       editor.setGrammar jsxGrammar if jsxGrammar


### PR DESCRIPTION
Fixes `Path must be a string. Received undefined` which happens with
Node 6 (included in Electron 1.1.0).
